### PR TITLE
V0.0.3 failed payments

### DIFF
--- a/instamojo.php
+++ b/instamojo.php
@@ -273,9 +273,18 @@ public function hookdisplayPayment($params) {
         } else {
             $redirect_url = 'http://' . htmlspecialchars($_SERVER['HTTP_HOST'], ENT_COMPAT, 'UTF-8') . __PS_BASE_URI__ . 'modules/instamojo/validation.php';
         }
+        $imphone = '';
+        $phone = $address->phone;
+        $phone_mobile = $address->phone_mobile;
+        if(!empty($phone_mobile)){
+            $imphone = $phone_mobile;
+        }
+        else{
+            $imphone = $phone;   
+        }
         $imname = substr(trim($address->firstname . ' ' . $address->lastname), 0, 20);
         $imemail = substr($email_address, 0, 75);
-        $imphone = substr(ltrim($address->phone_mobile, '+'), 0, 20);
+        $imphone = substr($imphone, 0, 20);
         $imamount = $amount;
         $imtid = $cartId . '-' . date('his');
 
@@ -315,7 +324,10 @@ public function hookdisplayPayment($params) {
 
         $str = hash_hmac("sha1", implode("|", $data), $private_salt);
 
-        $logger->logDebug("Signature is: $str");  
+        $logger->logDebug("Signature is: $str");
+        $imemail = urlencode($imemail);
+        $imname = urlencode($imname);
+        $imphone = urlencode($imphone);
 
         $payment_link = sprintf($payment_link, $custom_field, $custom_field, $custom_field, $imtid, $imname, $imemail, $imamount, $imphone, $str);
         $logger->logDebug("Payment link is: $payment_link");

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-Instamojo-PrestaShop v 0.0.2
+Instamojo-PrestaShop v 0.0.3
 ====
 ----
 This module allows us to use [Instamojo](https://www.instamojo.com) as Payment Gateway in PrestaShop websites.
@@ -63,6 +63,13 @@ This can be anything you want to display to the user on the checkout page, defau
 
 
 ----
+
+What's new in v 0.0.3
+----
+
+- Plugin will now support failed payments as well.
+- Name, phone and email are now urlencoded to handle special characters like `+` properly.
+- Now if mobile phone field is empty plugin will use the home phone field.
 
 What's new in v 0.0.2
 ----


### PR DESCRIPTION
- Plugin will now support failed payments as well.
- Name, phone and email are now urlencoded to handle special characters like `+` properly.
- Now if mobile phone field is empty plugin will use the home phone field.